### PR TITLE
Made the code Windows compatible

### DIFF
--- a/pyagram/pyagram.py
+++ b/pyagram/pyagram.py
@@ -112,12 +112,15 @@ def syntactic_analysis(src):
 
     return d
 
-def generate(in_file, out_path, image_type, src):
+def generate(in_file, out_path, image_type, src, fontname=None):
     dot_file = hashlib.md5(bytes(json.dumps(src), 'utf-8')).hexdigest()
     out_file = os.path.basename(in_file.replace('.txt', '.' + image_type))
     f_out = open(dot_file, 'w')
     f_out.write('digraph sample {')
-    f_out.write('graph [label="' + src['graph']['title'] + '",labelloc=t,fontsize=18];')
+    fontsetting = "fontname=\"" + fontname + "\"" if fontname else ""
+    f_out.write('graph [label="' + src['graph']['title'] + '",labelloc=t,fontsize=18,' + fontsetting + '];')
+    f_out.write('node ['+fontsetting+'];')
+    f_out.write('edge ['+fontsetting+'];')
     for key, value in src['views'].items():
         f_out.write('"' + key + '"' + '[peripheries=2,label="' + key + ' ' + value['path'] + '"];')
     for key, value in src['views'].items():
@@ -156,7 +159,7 @@ def generate(in_file, out_path, image_type, src):
     command2 = 'rm -f ' + dot_file
     os.system(command2)
 
-def compile(in_file, out_path, image_type):
+def compile(in_file, out_path, image_type, fontname=None):
     f_in = open(in_file, 'r')
     lines = []
     for line in f_in.readlines():
@@ -165,19 +168,20 @@ def compile(in_file, out_path, image_type):
             result1 = lexical_analysis(replaced_line)
             lines.append(result1)
     result2 = syntactic_analysis(lines)
-    generate(in_file, out_path, image_type, result2)
+    generate(in_file, out_path, image_type, result2, fontname=fontname)
 
 def main():
     parser = ArgumentParser(description='Pyagram: Diagram generator')
     parser.add_argument('-i', '--input', help='Input filename')
     parser.add_argument('-o', '--outpath', help='Output file path', default='.')
     parser.add_argument('-t', '--imagetype', help='Output image type')
+    parser.add_argument('-f', '--font', help='Fontname for labels')
     _args = parser.parse_args()
     if not _args.imagetype in ['gif', 'png', 'svg']:
         raise ValueError('Output image type must be gif, png or svg.')
     if not os.path.exists(_args.outpath):
         raise ValueError('Output file path must exist.')
-    compile(_args.input, _args.outpath, _args.imagetype)
+    compile(_args.input, _args.outpath, _args.imagetype, fontname=_args.font)
 
 if __name__ == '__main__':
     main()

--- a/pyagram/pyagram.py
+++ b/pyagram/pyagram.py
@@ -152,12 +152,12 @@ def generate(in_file, out_path, image_type, src, fontname=None):
                     f_out.write('"' + key + '"' + '->' + '"' + value3 + '";')
     f_out.write('}')
     f_out.flush()
+    f_out.close()
 
     command1 = 'dot -T' + image_type + ' -o ' + out_path + '/' + out_file + ' ' + dot_file
     os.system(command1)
 
-    command2 = 'rm -f ' + dot_file
-    os.system(command2)
+    os.remove(dot_file)
 
 def compile(in_file, out_path, image_type, fontname=None):
     f_in = open(in_file, 'r', encoding='utf-8')

--- a/pyagram/pyagram.py
+++ b/pyagram/pyagram.py
@@ -115,7 +115,7 @@ def syntactic_analysis(src):
 def generate(in_file, out_path, image_type, src, fontname=None):
     dot_file = hashlib.md5(bytes(json.dumps(src), 'utf-8')).hexdigest()
     out_file = os.path.basename(in_file.replace('.txt', '.' + image_type))
-    f_out = open(dot_file, 'w')
+    f_out = open(dot_file, 'w', encoding='utf-8')
     f_out.write('digraph sample {')
     fontsetting = "fontname=\"" + fontname + "\"" if fontname else ""
     f_out.write('graph [label="' + src['graph']['title'] + '",labelloc=t,fontsize=18,' + fontsetting + '];')
@@ -160,7 +160,7 @@ def generate(in_file, out_path, image_type, src, fontname=None):
     os.system(command2)
 
 def compile(in_file, out_path, image_type, fontname=None):
-    f_in = open(in_file, 'r')
+    f_in = open(in_file, 'r', encoding='utf-8')
     lines = []
     for line in f_in.readlines():
         replaced_line = str(line.replace('\n',''))


### PR DESCRIPTION
For Windows:
- Fontname have to be configurable (see: http://d.hatena.ne.jp/simply-k/20100705/1278326617 (written in Japanese)).
- Encoding should be declared explicitly as opening file stream.
- `rm` command fails with permission error; os.remove works instead.

I checked on Windows. I don't have Mac OS, so please check on Mac OS before accepting this pull request.
