### PR TITLE
Add filename extension of output file

### DIFF
--- a/pyagram/pyagram.py
+++ b/pyagram/pyagram.py
@@ -114,7 +114,7 @@ def syntactic_analysis(src):
 
 def generate(in_file, out_path, image_type, src, fontname=None):
     dot_file = hashlib.md5(bytes(json.dumps(src), 'utf-8')).hexdigest()
-    out_file = os.path.basename(in_file.replace('.txt', '.' + image_type))
+    out_file = os.path.basename(os.path.splitext(in_file)[0]) + '.' + image_type
     f_out = open(dot_file, 'w', encoding='utf-8')
     f_out.write('digraph sample {')
     fontsetting = "fontname=\"" + fontname + "\"" if fontname else ""


### PR DESCRIPTION
Hi. Thank you for a nice tool!

I modified a little.

The output file could be added file extension when input file extension is `.txt` only. So,  it is useful when it has any file extension include nothing.
