### PR TITLE
Support some chars in label

### DIFF
--- a/pyagram/pyagram.py
+++ b/pyagram/pyagram.py
@@ -10,7 +10,7 @@ import json
 import pprint
 
 def lexical_analysis(src):
-    string = pp.Regex('[a-zA-Z0-9_{}"=+\-*/\.:; ａ-ｚＡ-Ｚぁ-ゔゞァ-・ヽヾ゛゜ー一-龯]+')
+    string = pp.Regex('[a-zA-Z0-9_{}"=+\-*/\.:;&%@$#<>? ａ-ｚＡ-Ｚぁ-ゔゞァ-・ヽヾ゛゜ー一-龯]+')
 
     blank = pp.LineStart() + pp.LineEnd()
 


### PR DESCRIPTION
For example, input file is following.

```
#[item1&item2]
test

==> item3

#[item3]
```

Then ParseException is raised. Due to `&` is contained in label. Other chars are `%@$#<>?`. It might be, there are more chars. In particular, unicode chars. However I think It’s enough for the time being.
