### PR TITLE
Fixed an error when font option was not set

### DIFF
--- a/pyagram/entity_relationship_diagram.py
+++ b/pyagram/entity_relationship_diagram.py
@@ -61,7 +61,8 @@ class EntityRelationshipDiagram(Diagram):
     def generate_dot(self, src):
         dot = 'digraph erd{node[shape=record];'
         fontsetting = 'fontname="' + self.fontname + '"' if self.fontname else ''
-        dot += 'node [' + fontsetting + ', style="rounded"];'
+        node_prop = ', '.join(filter(None, [fontsetting, 'style="rounded"']))
+        dot += 'node [' + node_prop + '];'
         dot += 'edge [' + fontsetting + '];'
         for table in src['src']:
             for k, v in table.items():


### PR DESCRIPTION
When font option was not set in ER-diagram, I had a syntax error.

```
% pyagram -t png -i erd -d erd
Error: afcc8c81649acc940dd17c6744e55a6e: syntax error in line 1 near ','
```

Fixed it.
